### PR TITLE
標準出力とファイルにログ同時出力機能を追加

### DIFF
--- a/rtmbot_mattermost/core.py
+++ b/rtmbot_mattermost/core.py
@@ -66,7 +66,10 @@ class RtmBot(object):
             log_level = logging.DEBUG
         else:
             log_level = logging.INFO
-        logging.basicConfig(filename=log_file,
+        file_handler = logging.FileHandler(filename=log_file)
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        handlers = [file_handler,stdout_handler]
+        logging.basicConfig(handlers=handlers,
                             level=log_level,
                             format='%(asctime)s %(message)s')
         logging.info('Initialized in: {}'.format(self.directory))


### PR DESCRIPTION
bot のログを標準出力とログファイルに同時出力できるようにしました。
標準出力用のハンドラとログファイル出力のハンドラを両方設定することで、標準出力とログファイル出力を両立することに成功しました。
標準出力を有効にしたことで docker コンテナ内のログを docker-compose logs で参照できるようになりました。
また、ファイル出力を有効にしたことでログの保存が簡単にできるようになりました。
差し支えなければ merge をよろしくお願いします。

logger で複数のハンドラを使用する方法: https://docs.python.org/3/howto/logging-cookbook.html#multiple-handlers-and-formatters